### PR TITLE
bump version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "recordrtc",
-  "version": "5.0.1",
+  "version": "5.0.4",
   "authors": [
         {
             "name": "Muaz Khan",


### PR DESCRIPTION
The bower version nr wasn't updated during the latest release. Bumping version in `bower.json`.
