### PR TITLE
changed mergeAudioBuffers to a function declaration to preserve the name...

### DIFF
--- a/dev/StereoAudioRecorder.js
+++ b/dev/StereoAudioRecorder.js
@@ -52,7 +52,7 @@ function StereoAudioRecorder(mediaStream, config) {
     };
 
     function mergeLeftRightBuffers(config, callback) {
-        var webWorker = processInWebWorker(function mergeAudioBuffers(config) {
+        function mergeAudioBuffers(config) {
             var leftBuffers = config.leftBuffers;
             var rightBuffers = config.rightBuffers;
             var sampleRate = config.sampleRate;
@@ -171,7 +171,8 @@ function StereoAudioRecorder(mediaStream, config) {
                 buffer: buffer,
                 view: view
             });
-        });
+        }
+        var webWorker = processInWebWorker(mergeAudioBuffers);
 
         webWorker.onmessage = function(event) {
             callback(event.data.buffer, event.data.view);
@@ -182,7 +183,7 @@ function StereoAudioRecorder(mediaStream, config) {
 
     function processInWebWorker(_function) {
         var blob = URL.createObjectURL(new Blob([_function.toString(),
-            'this.onmessage =  function (e) {mergeAudioBuffers(e.data);}'
+            'this.onmessage =  function (e) {' + _function.name + '(e.data);}'
         ], {
             type: 'application/javascript'
         }));


### PR DESCRIPTION
Hi,
  In Chrome RecordRTC.min.js I think has an issue with minification obscuring the function expression mergeAudioBuffers in StereoAudioRecorder.js.  The minifier removes the mergeAudioBuffers from the function expression.  Later when 

'this.onmessage =  function (e) {mergeAudioBuffers(e.data);}' 

is called mergeAudioBuffers is not found I believe.  In order to preserve 'mergeAudioBuffers' function name until it is called later it is converted to a function declaration and appealed to as _function.name in processWebWorker.

Here is an example using https://webrtcexperiment-webrtc.netdna-ssl.com/RecordRTC.min.js

http://jsfiddle.net/jimlowrey/m2ev2meh/

and the modification using an inlined version from my local machine.

http://jsfiddle.net/jimlowrey/xpLr508k/ 

Not sure if I should check in the resulting RecordRTC.js and RecordRTC.min.js.

Please let me know if you think this is the best way to go about this and if you want any more information.

Thanks for the awesome resource!
