### PR TITLE
Making RecordRTC module friendly

### DIFF
--- a/RecordRTC.js
+++ b/RecordRTC.js
@@ -2971,3 +2971,5 @@ function GifRecorder(mediaStream) {
 
     var gifEncoder;
 }
+
+module.exports = RecordRTC;


### PR DESCRIPTION
I've simply exported the RecordRTC function, since this encapsulates the public API.  Note that I haven't updated the minified version.

Fixes #27 
