### PR TITLE
Correct version number.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "recordrtc",
-  "version": "5.2.6",
+  "version": "5.2.7",
   "authors": [
         {
             "name": "Muaz Khan",


### PR DESCRIPTION
Bower complained for a good reason:

```
bower recordrtc#>=5.2.7       mismatch Version declared in the json (5.2.6) is different than the resolved one (5.2.7)
```