### PR TITLE
DEPRECATED eregi

### DIFF
--- a/PHP-and-FFmpeg/save.php
+++ b/PHP-and-FFmpeg/save.php
@@ -32,7 +32,7 @@
     foreach($OSList as $CurrOS=>$Match)
     {
         // Find a match
-        if (eregi($Match, $_SERVER['HTTP_USER_AGENT']))
+        if (preg_match("/".$Match."/i", $_SERVER['HTTP_USER_AGENT']))
         {
             // We found the correct match
             break;


### PR DESCRIPTION
This function was DEPRECATED in PHP 5.3.0, and REMOVED in PHP 7.0.0.