### PR TITLE
Bugfix + getter

### DIFF
--- a/dev/RecordRTC.js
+++ b/dev/RecordRTC.js
@@ -86,7 +86,6 @@ function RecordRTC(mediaStream, config) {
         }
 
         if (self.state === 'paused') {
-            setState('recording');
 
             self.resumeRecording();
 

--- a/dev/RecordRTC.js
+++ b/dev/RecordRTC.js
@@ -665,7 +665,17 @@ function RecordRTC(mediaStream, config) {
          * })();
          * recorder.startRecording();
          */
-        state: 'inactive'
+        state: 'inactive',
+
+        /**
+         *
+         * State getter
+         *
+         * @returns {*}
+         */
+        getState: function() {
+            return self.state;
+        }
     };
 
     if (!this) {


### PR DESCRIPTION
Hi !

I play with recordRTC lib and find that stopRecording doesn't work when paused.

After little investigation I found a bug. As I understand it is incorrect to manually set state to recording and then try to resume, it will not work. So I fixed it.

Second piece of code is additional getter. When I work with lib, object.state is always 'inactive', so I added a getter.