### PR TITLE
[StereoAudioRecorder] fix stop callback

### DIFF
--- a/RecordRTC.js
+++ b/RecordRTC.js
@@ -2620,7 +2620,7 @@ function StereoAudioRecorder(mediaStream, config) {
             self.length = recordingLength;
 
             if (callback) {
-                callback();
+                callback(self.blob);
             }
 
             isAudioProcessStarted = false;

--- a/dev/StereoAudioRecorder.js
+++ b/dev/StereoAudioRecorder.js
@@ -394,7 +394,7 @@ function StereoAudioRecorder(mediaStream, config) {
             self.length = recordingLength;
 
             if (callback) {
-                callback();
+                callback(self.blob);
             }
 
             isAudioProcessStarted = false;


### PR DESCRIPTION
http://recordrtc.org/StereoAudioRecorder.html#.this.stop
in the example the callback function has <code>blob<code> as an argument, however, in the implementation there is not. added now.