### PR TITLE
Close AudioContext

### DIFF
--- a/RecordRTC.js
+++ b/RecordRTC.js
@@ -5167,6 +5167,9 @@ function MultiStreamsMixer(arrayOfMediaStreams) {
             self.audioDestination = null;
         }
 
+        if (self.audioContext) {
+            self.audioContext.close();
+        }
         self.audioContext = null;
 
         context.clearRect(0, 0, canvas.width, canvas.height);


### PR DESCRIPTION
With this change the `MultiStreamsMixer`'s  `releaseStreams` function will close its current audioContext. before this change , the audioContext was assigned null without closing it.





This fixes #385