### PR TITLE
fix browser detection for chrome

### DIFF
--- a/dev/Cross-Browser-Declarations.js
+++ b/dev/Cross-Browser-Declarations.js
@@ -87,8 +87,8 @@ if (typeof navigator !== 'undefined' && typeof navigator.getUserMedia === 'undef
 
 var isEdge = navigator.userAgent.indexOf('Edge') !== -1 && (!!navigator.msSaveBlob || !!navigator.msSaveOrOpenBlob);
 var isOpera = !!window.opera || navigator.userAgent.indexOf('OPR/') !== -1;
-var isSafari = navigator.userAgent.toLowerCase().indexOf('safari/') > -1;
-var isChrome = (!isOpera && !isEdge && !!navigator.webkitGetUserMedia) || isElectron() || isSafari;
+var isSafari = navigator.userAgent.toLowerCase().indexOf('safari/') !== -1 && navigator.userAgent.toLowerCase().indexOf('chrome/') === -1;
+var isChrome = (!isOpera && !isEdge && !!navigator.webkitGetUserMedia) || isElectron() || navigator.userAgent.toLowerCase().indexOf('chrome/') !== -1;
 
 var MediaStream = window.MediaStream;
 


### PR DESCRIPTION
and of course Safari.

This causes problems when selecting whether to run `mergeAudioBuffers` in a web worker or not.

When running `mergeAudioBuffers` not in a web worker on slow systems there are some audio distortions when processing the previous chunk (when using the `ondataavailable` handler).

General question from my side: Why do you check for browsers like Safari, Opera and Edge? As far as I can see (https://caniuse.com/#search=Worker) checking whether the browser supports Workers or not should not be necessary anymore.