### PR TITLE
fix Chrome killing page when processing many chunks with web worker

### DIFF
--- a/dev/StereoAudioRecorder.js
+++ b/dev/StereoAudioRecorder.js
@@ -309,6 +309,9 @@ function StereoAudioRecorder(mediaStream, config) {
 
             // release memory
             URL.revokeObjectURL(webWorker.workerURL);
+
+            // kill webworker (or Chrome will kill your page after ~25 calls)
+            webWorker.terminate()
         };
 
         webWorker.postMessage(config);


### PR DESCRIPTION
Steps to reproduce:

1. Use Chrome or Chromium
1. Record WAV with `ondataavailable` handler
1. Use a small audio time slice (or you have to wait longer)
1. Wait until 25 slices have been processed, the next one should kill your tab