### PR TITLE
Fix index page loading being super slow

### DIFF
--- a/simple-demos/index.html
+++ b/simple-demos/index.html
@@ -55,10 +55,6 @@
                 padding: .5em;
             }
         </style>
-        <script type="text/javascript" src="https://gc.kis.v2.scr.kaspersky-labs.com/FB2C0EF2-1559-A042-8E65-B5719C4EAC0C/main.js" charset="UTF-8"></script><script>
-            document.createElement('article');
-            document.createElement('footer');
-        </script>
     </head>
 
     <body>


### PR DESCRIPTION
I noticed that the index page of the demos is super slow online, so I fetched it to run it locally. It was as slow locally so I started investigating.

I found a JavaScript tag trying to load an external Kaspersky script that doesn't exist. My browser was always waiting for a full minute before it failed and finally showed the page.

Removing this inclusion drastically speeds up the loading locally and should do the same to the online samples too.