### PR TITLE
Replace getScreenId call with getDisplayMedia

### DIFF
--- a/simple-demos/record-cropped-screen.html
+++ b/simple-demos/record-cropped-screen.html
@@ -126,14 +126,26 @@ function CropFrame(ev, stream, video, callback) {
 
 var recorder;
 
-function captureScreen(cb) {
-    getScreenId(function(error, sourceId, screen_constraints) {
-        navigator.mediaDevices.getUserMedia(screen_constraints).then(cb).catch(function(error) {
-            console.error('getScreenId error', error);
-
-            alert('Failed to capture your screen. Please check Chrome console logs for further information.');
+function getScreenStream(callback) {
+    if (navigator.getDisplayMedia) {
+        navigator.getDisplayMedia({
+            video: true
+        }).then(screenStream => {
+            callback(screenStream);
         });
-    });
+    } else if (navigator.mediaDevices.getDisplayMedia) {
+        navigator.mediaDevices.getDisplayMedia({
+            video: true
+        }).then(screenStream => {
+            callback(screenStream);
+        });
+    } else {
+        getScreenId(function(error, sourceId, screen_constraints) {
+            navigator.mediaDevices.getUserMedia(screen_constraints).then(function(screenStream) {
+                callback(screenStream);
+            });
+        });
+    }
 }
 
 var mediaElement = document.querySelector('#mediaElement');
@@ -141,7 +153,7 @@ var mediaElement = document.querySelector('#mediaElement');
 document.querySelector('#btn-start-recording').onclick = function() {
     document.querySelector('#btn-start-recording').style.display = 'none';
 
-    captureScreen(function(screen) {
+    getScreenStream(function(screen) {
         var inited = false;
 
         mediaElement.ontimeupdate = function(ev) {


### PR DESCRIPTION
I came across the `record-cropped-screen` demo and it didn't work for me.

I eventually found out I needed to install a separate extension, but in the meantime I fixed it by using the `getScreenStream` function you provided on other repos.

This is an updated version of the demo that uses `getScreenStream`. Works on Chrome 73 and Firefox 66 without extensions.