### PR TITLE
Updated deprecated MediaStream.stop() in Audio recorder example

### DIFF
--- a/simple-demos/audio-recording.html
+++ b/simple-demos/audio-recording.html
@@ -180,7 +180,7 @@ btnReleaseMicrophone.onclick = function() {
     btnStartRecording.disabled = false;
 
     if(microphone) {
-        microphone.stop();
+        microphone.getTracks().forEach( t => t.stop());();
         microphone = null;
     }
 


### PR DESCRIPTION
Replaced microphone.stop() with microphone.getTracks().forEach( t => t.stop());

MediaStream.stop() is deprecated according to https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API.