### PR TITLE
add playsinline video element attribute to prevent build-in controls

### DIFF
--- a/dev/GifRecorder.js
+++ b/dev/GifRecorder.js
@@ -261,6 +261,7 @@ function GifRecorder(mediaStream, config) {
         var video = document.createElement('video');
         video.muted = true;
         video.autoplay = true;
+        video.playsinline = true;
 
         isLoadedMetaData = false;
         video.onloadedmetadata = function() {

--- a/dev/GifRecorder.js
+++ b/dev/GifRecorder.js
@@ -261,7 +261,7 @@ function GifRecorder(mediaStream, config) {
         var video = document.createElement('video');
         video.muted = true;
         video.autoplay = true;
-        video.playsinline = true;
+        video.playsInline = true;
 
         isLoadedMetaData = false;
         video.onloadedmetadata = function() {


### PR DESCRIPTION
Add playsinline=true video element attribute for GifRecorder to prevent iOS Safari automatically enters fullscreen mode and display built-in controls.

Fixes muaz-khan/RecordRTC#571