### PR TITLE
isTypeSupported example: add audio/mp4

### DIFF
--- a/simple-demos/isTypeSupported.html
+++ b/simple-demos/isTypeSupported.html
@@ -65,11 +65,12 @@ h1, p {
 <script>
 var mimeTypes = [
     ['video/webm', ['Chrome', 'Firefox', 'Safari']],
-    ['video/mp4', []],
+    ['video/mp4', ['Safari']],
     ['video/mpeg', []],
     ['audio/wav', []],
     ['audio/webm', ['Chrome', 'Firefox', 'Safari']],
     ['audio/ogg', ['Firefox']],
+    ['audio/mp4', ['Safari']],
     ['video/webm;codecs=vp8', ['Chrome', 'Firefox', 'Safari']],
     ['video/webm;codecs=vp9', ['Chrome']],
     ['video/webm;codecs=h264', ['Chrome']],


### PR DESCRIPTION
according to this blog post, latest safari also supports audio/mp4: https://webkit.org/blog/11353/mediarecorder-api/

And testing the example on Safari 14.0.2 shows only video/mp4 is supported (and audio/mp4 once it's added to the list).