### PR TITLE
createObjectURL is deprecated for Google Chrome

### DIFF
--- a/RecordRTC-over-Socketio/index.html
+++ b/RecordRTC-over-Socketio/index.html
@@ -114,7 +114,7 @@
                 onAudioProcessStarted: function() {
                     recordVideo.startRecording();
 
-                    cameraPreview.src = window.URL.createObjectURL(stream);
+                    cameraPreview.srcObject=stream;
                     cameraPreview.play();
 
                     cameraPreview.muted = true;


### PR DESCRIPTION
video.src = window.URL.createObjectURL(localMediaStream);
video.play();

Then I replaced that with this:

video.srcObject = localMediaStream;
video.play();