### PR TITLE
stopRecording function issues fixes in recordrtc

### DIFF
--- a/RecordRTC.js
+++ b/RecordRTC.js
@@ -109,6 +109,7 @@ function RecordRTC(mediaStream, config) {
 
         if (!mediaRecorder) {
             warningLog();
+            callback();
             return;
         }
 
@@ -118,6 +119,7 @@ function RecordRTC(mediaStream, config) {
             setTimeout(function() {
                 stopRecording(callback);
             }, 1);
+            callback();
             return;
         }
 


### PR DESCRIPTION
issue was when media recorder state changed to pause or media recorder becomes undefined then it is not returning anything to the calling function.