### PR TITLE
fix: gif recorder config param corrected

### DIFF
--- a/simple-demos/gif-recording.html
+++ b/simple-demos/gif-recording.html
@@ -49,7 +49,7 @@ document.getElementById('btn-start-recording').onclick = function() {
             frameRate: 1,
             quality: 10,
             width: 360,
-            hidden: 240,
+            height: 240,
             onGifRecordingStarted: function() {
                 document.querySelector('h1').innerHTML = 'Gif recording started.';
             },


### PR DESCRIPTION
`hidden` param is unexpected for gif recorder according [documentation](https://recordrtc.org/GifRecorder.html)