### PR TITLE
Keep iOS chrome identified as safari because it is

### DIFF
--- a/dev/Cross-Browser-Declarations.js
+++ b/dev/Cross-Browser-Declarations.js
@@ -92,11 +92,6 @@ var isChrome = (!isOpera && !isEdge && !!navigator.webkitGetUserMedia) || isElec
 
 var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
-if (isSafari && !isChrome && navigator.userAgent.indexOf('CriOS') !== -1) {
-    isSafari = false;
-    isChrome = true;
-}
-
 var MediaStream = window.MediaStream;
 
 if (typeof MediaStream === 'undefined' && typeof webkitMediaStream !== 'undefined') {


### PR DESCRIPTION
Related issues (probably more):
https://github.com/muaz-khan/RecordRTC/issues/833
https://github.com/muaz-khan/RecordRTC/issues/825
https://github.com/muaz-khan/RecordRTC/issues/793

This section of code ends up causing issues in other areas because iOS Chrome _is actually Safari_ (WKWebView technically). It does _not_ support webm recording like usual Chrome, but instead natively supports mp4 recording like Safari. So you should not be making determinations of what is usually supported in Chrome if it is actually a WKWebView.

This causes the "auto" `recorderType` determination to end up trying to use `WebAssemblyRecorder` when it should use `MediaStreamRecorder`. Furthermore, if you force `MediaStreamRecorder` to be used, then it ends up failing the `isMediaRecorderCompatible` check (because it thinks it is in Chrome but that helper internally doesn't factor in CriOS) which overrides any `recorderHints` passed in.

It's better to just treat CriOS browsers as Safari, because again it is a WKWebView which should be just viewed as Safari.